### PR TITLE
Additonal check for dataparallel, loss_lr_scheduler support

### DIFF
--- a/distiller/apputils/checkpoint.py
+++ b/distiller/apputils/checkpoint.py
@@ -13,7 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+###################################################################################################
+#
+# Portions Copyright (C) 2023 Analog Devices, Inc. All Rights Reserved.
+#
+# Analog Devices, Inc. Default Copyright Notice:
+# https://www.analog.com/en/about-adi/legal-and-risk-oversight/intellectual-property/copyright-notice.html
+#
+###################################################################################################
 """ Helper code for checkpointing models, with support for saving the pruning schedule.
 
 Adding the schedule information in the model checkpoint is helpful in resuming
@@ -227,6 +234,11 @@ def load_checkpoint(model, chkpt_file, optimizer=None,
         if qmd.get('pytorch_convert', False):
             msglogger.info('Converting Distiller PTQ model to PyTorch quantization API')
             model = quantizer.convert_to_pytorch(qmd['dummy_input'], backend=qmd.get('pytorch_convert_backend', None))
+
+    for k, v in checkpoint['state_dict'].items():
+        if 'module' in k:
+            normalize_dataparallel_keys = True
+            break
 
     if normalize_dataparallel_keys:
         checkpoint['state_dict'] = {normalize_module_name(k): v for k, v in checkpoint['state_dict'].items()}

--- a/distiller/apputils/checkpoint.py
+++ b/distiller/apputils/checkpoint.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
 """ Helper code for checkpointing models, with support for saving the pruning schedule.
 
 Adding the schedule information in the model checkpoint is helpful in resuming

--- a/distiller/apputils/checkpoint.py
+++ b/distiller/apputils/checkpoint.py
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2018 Intel Corporation
+# Portions Copyright (C) 2023 Analog Devices, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,14 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-###################################################################################################
-#
-# Portions Copyright (C) 2023 Analog Devices, Inc. All Rights Reserved.
-#
-# Analog Devices, Inc. Default Copyright Notice:
-# https://www.analog.com/en/about-adi/legal-and-risk-oversight/intellectual-property/copyright-notice.html
-#
-###################################################################################################
 """ Helper code for checkpointing models, with support for saving the pruning schedule.
 
 Adding the schedule information in the model checkpoint is helpful in resuming

--- a/distiller/config.py
+++ b/distiller/config.py
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2018 Intel Corporation
+# Portions Copyright (C) 2023 Analog Devices, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,14 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-###################################################################################################
-#
-# Portions Copyright (C) 2023 Analog Devices, Inc. All Rights Reserved.
-#
-# Analog Devices, Inc. Default Copyright Notice:
-# https://www.analog.com/en/about-adi/legal-and-risk-oversight/intellectual-property/copyright-notice.html
-#
-###################################################################################################
 
 """CompressionScheduler configuration parsing.
 

--- a/distiller/config.py
+++ b/distiller/config.py
@@ -13,6 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+###################################################################################################
+#
+# Portions Copyright (C) 2023 Analog Devices, Inc. All Rights Reserved.
+#
+# Analog Devices, Inc. Default Copyright Notice:
+# https://www.analog.com/en/about-adi/legal-and-risk-oversight/intellectual-property/copyright-notice.html
+#
+###################################################################################################
 
 """CompressionScheduler configuration parsing.
 
@@ -49,7 +57,7 @@ msglogger = logging.getLogger()
 app_cfg_logger = logging.getLogger("app_cfg")
 
 
-def dict_config(model, optimizer, sched_dict, scheduler=None, resumed_epoch=None):
+def dict_config(model, optimizer, sched_dict, scheduler=None, resumed_epoch=None, loss_optimizer=None):
     app_cfg_logger.debug('Schedule contents:\n' + json.dumps(sched_dict, indent=2))
 
     if scheduler is None:
@@ -64,6 +72,7 @@ def dict_config(model, optimizer, sched_dict, scheduler=None, resumed_epoch=None
 
     try:
         lr_policies = []
+        loss_lr_policies = []
         for policy_def in sched_dict['policies']:
             policy = None
             if 'pruner' in policy_def:
@@ -98,6 +107,12 @@ def dict_config(model, optimizer, sched_dict, scheduler=None, resumed_epoch=None
                 lr_policies.append(policy_def)
                 continue
 
+            elif 'loss_lr_scheduler' in policy_def:
+                # LR schedulers take an optimizer in their constructor, so postpone handling until we're certain
+                # a quantization policy was initialized (if exists)
+                loss_lr_policies.append(policy_def)
+                continue
+
             elif 'extension' in policy_def:
                 instance_name, args = __policy_params(policy_def, 'extension')
                 assert instance_name in extensions, "Extension {} was not defined in the list of extensions".format(instance_name)
@@ -119,6 +134,16 @@ def dict_config(model, optimizer, sched_dict, scheduler=None, resumed_epoch=None
             lr_scheduler = lr_schedulers[instance_name]
             policy = distiller.LRPolicy(lr_scheduler)
             add_policy_to_scheduler(policy, policy_def, scheduler)
+        
+        if loss_optimizer is not None:
+            loss_lr_schedulers = __factory('loss_lr_schedulers', model, sched_dict, optimizer=loss_optimizer,
+                                           last_epoch=(resumed_epoch if resumed_epoch is not None else -1))
+            for policy_def in loss_lr_policies:
+                instance_name, args = __policy_params(policy_def, 'loss_lr_scheduler')
+                if  instance_name in loss_lr_schedulers:
+                    lr_scheduler = loss_lr_schedulers[instance_name]
+                    policy = distiller.LRPolicy(lr_scheduler)
+                    add_policy_to_scheduler(policy, policy_def, scheduler)
 
     except AssertionError:
         # propagate the assertion information
@@ -139,13 +164,13 @@ def add_policy_to_scheduler(policy, policy_def, scheduler):
                             frequency=policy_def['frequency'])
 
 
-def file_config(model, optimizer, filename, scheduler=None, resumed_epoch=None):
+def file_config(model, optimizer, filename, scheduler=None, resumed_epoch=None, loss_optimizer=None):
     """Read the schedule from file"""
     with open(filename, 'r') as stream:
         msglogger.info('Reading compression schedule from: %s', filename)
         try:
             sched_dict = distiller.utils.yaml_ordered_load(stream)
-            return dict_config(model, optimizer, sched_dict, scheduler, resumed_epoch)
+            return dict_config(model, optimizer, sched_dict, scheduler, resumed_epoch, loss_optimizer)
         except yaml.YAMLError as exc:
             print("\nFATAL parsing error while parsing the schedule configuration file %s" % filename)
             raise


### PR DESCRIPTION
There are two updates:

1. Additional check for normalizing dataparallel keys when loading a checkpoint. When using dataparallel, at first run a comp. scheduler is created from a dataparallel model. Then when saving the checkpoint, both model and scheduler are saved with dataparallel keys. On the second run, when loading checkpoint, _load_compression_scheduler(): function catches an exception and returns "normalize_dataparallel_keys" as True.  Then using this flag, dataparallel keys are removed from the checkpoint. The problem starts at this point because the model will be sent to dataparallel again in the main loop and will be saved as dataparallel. However, comp. scheduler keys will remain as normalized, and  _load_compression_scheduler(): will not catch an exception. Therefore, when trying to load for the third time with dataparallel missing_leys value error will be raised. To prevent this, I added an additional check that directly searches for the "module" keyword in the checkpoint state dict.

2. Loss lr scheduler support will enable the usage of an additional lr policy that schedules the second (loss) optimizer. For the faceID case after trials, I didn't have to use this. However, it may be useful for applications in the future. 